### PR TITLE
to make possible colorized output

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible/workflow/AnsiblePlaybookStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/workflow/AnsiblePlaybookStep.java
@@ -48,6 +48,7 @@ public class AnsiblePlaybookStep extends AbstractStepImpl {
     private String skippedTags = null;
     private String startAtTask = null;
     private String extras = null;
+    public boolean colorizedOutput = false;
 
     @DataBoundConstructor
     public AnsiblePlaybookStep(String playbook) {
@@ -104,6 +105,11 @@ public class AnsiblePlaybookStep extends AbstractStepImpl {
         this.extras = Util.fixEmptyAndTrim(extras);
     }
 
+    @DataBoundSetter
+    public void setColorizedOutput(boolean colorizedOutput) {
+        this.colorizedOutput = colorizedOutput;
+    }
+
     public String getInstallation() {
         return installation;
     }
@@ -146,6 +152,10 @@ public class AnsiblePlaybookStep extends AbstractStepImpl {
 
     public String getExtras() {
         return extras;
+    }
+
+    public boolean isColorizedOutput() {
+        return colorizedOutput;
     }
 
     @Extension
@@ -224,7 +234,7 @@ public class AnsiblePlaybookStep extends AbstractStepImpl {
             builder.setAdditionalParameters(step.getExtras());
             builder.setHostKeyChecking(false);
             builder.setUnbufferedOutput(true);
-            builder.setColorizedOutput(false);
+            builder.setColorizedOutput(step.isColorizedOutput());
             builder.perform(run, computer.getNode(), ws, launcher, listener, envVars);
             return null;
         }

--- a/src/main/resources/org/jenkinsci/plugins/ansible/workflow/AnsiblePlaybookStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ansible/workflow/AnsiblePlaybookStep/config.jelly
@@ -33,4 +33,7 @@
     <f:entry field="extras" title="Extra parameters">
         <f:textbox/>
     </f:entry>
+    <f:entry title="${%Colorized stdout}" field="colorizedOutput">
+        <f:checkbox default="false" />
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
example usage:

```
wrap([$class: 'hudson.plugins.ansicolor.AnsiColorBuildWrapper']) {
                ansiblePlaybook playbook: 'run.yml',
                    extras: "-vv -e service_version=$SERVICE_VERSION", 
                    installation: 'default',
                    colorizedOutput: true,
                    inventory: "$HOST,"
            }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/ansible-plugin/3)
<!-- Reviewable:end -->
