### PR TITLE
Use current job environment variable content in ansible executions

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleInvocation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleInvocation.java
@@ -40,7 +40,7 @@ abstract class AbstractAnsibleInvocation<T extends AbstractAnsibleInvocation<T>>
     protected final EnvVars envVars;
     protected final TaskListener listener;
     protected final Run<?, ?> build;
-    protected final Map<String, String> environment = new HashMap<String, String>();
+    protected final Map<String, String> environment;
 
     protected String exe;
     protected int forks;
@@ -61,6 +61,7 @@ abstract class AbstractAnsibleInvocation<T extends AbstractAnsibleInvocation<T>>
         this.build = build;
         this.ws = ws;
         this.envVars = build.getEnvironment(listener);
+        this.environment = new HashMap<String, String>(this.envVars);
         this.listener = listener;
         this.exe = exe;
         if (exe == null) {


### PR DESCRIPTION
Currently when ansible or ansible-playbook are ran, environment variables to pass into the execution are seeded from an empty hashmap with some implicit variables added via code.  This makes runs somewhat prohibitive as they are not able to make use of various plugins which can be used to pass environment context to the execution, including things like the EnvInject plugin or parameterized builds.  This pull request suggests a simple change that would seed the environment variables from the current jobs environment so that they are passed down to the execution of ansible.  This would be in line with other task oriented plugins such as maven, python or shell.