### PR TITLE
Make use of the AnsiblePlaybookStep envVars

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleInvocation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleInvocation.java
@@ -57,12 +57,12 @@ abstract class AbstractAnsibleInvocation<T extends AbstractAnsibleInvocation<T>>
     private boolean copyCredentialsInWorkspace = false;
     private final FilePath ws;
 
-    protected AbstractAnsibleInvocation(String exe, Run<?, ?> build, FilePath ws, TaskListener listener)
+    protected AbstractAnsibleInvocation(String exe, Run<?, ?> build, FilePath ws, TaskListener listener, EnvVars envVars)
             throws IOException, InterruptedException, AnsibleInvocationException
     {
         this.build = build;
         this.ws = ws;
-        this.envVars = build.getEnvironment(listener);
+        this.envVars = envVars;
         this.environment = new HashMap<String, String>(this.envVars);
         this.listener = listener;
         this.exe = exe;

--- a/src/main/java/org/jenkinsci/plugins/ansible/AnsibleAdHocCommandBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AnsibleAdHocCommandBuilder.java
@@ -21,11 +21,7 @@ import java.util.List;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
-import hudson.AbortException;
-import hudson.Extension;
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.Util;
+import hudson.*;
 import hudson.model.Computer;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -164,8 +160,9 @@ public class AnsibleAdHocCommandBuilder extends Builder implements SimpleBuildSt
             if (computer == null) {
                 throw new AbortException("The ansible playbook build step requires to be launched on a node");
             }
-            String exe = AnsibleInstallation.getExecutable(ansibleName, AnsibleCommand.ANSIBLE, computer.getNode(), listener, run.getEnvironment(listener));
-            AnsibleAdHocCommandInvocation invocation = new AnsibleAdHocCommandInvocation(exe, run, ws, listener);
+            EnvVars envVars = run.getEnvironment(listener);
+            String exe = AnsibleInstallation.getExecutable(ansibleName, AnsibleCommand.ANSIBLE, computer.getNode(), listener, envVars);
+            AnsibleAdHocCommandInvocation invocation = new AnsibleAdHocCommandInvocation(exe, run, ws, listener, envVars);
             invocation.setHostPattern(hostPattern);
             invocation.setInventory(inventory);
             invocation.setModule(module);

--- a/src/main/java/org/jenkinsci/plugins/ansible/AnsibleAdHocCommandInvocation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AnsibleAdHocCommandInvocation.java
@@ -17,6 +17,7 @@ package org.jenkinsci.plugins.ansible;
 
 import java.io.IOException;
 
+import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -38,13 +39,13 @@ public class AnsibleAdHocCommandInvocation extends AbstractAnsibleInvocation<Ans
     protected AnsibleAdHocCommandInvocation(String exe, AbstractBuild<?, ?> build, BuildListener listener)
             throws IOException, InterruptedException, AnsibleInvocationException
     {
-        super(exe, build, build.getWorkspace(), listener);
+        super(exe, build, build.getWorkspace(), listener, build.getEnvironment(listener));
     }
 
-    public AnsibleAdHocCommandInvocation(String exe, Run<?, ?> build, FilePath ws, TaskListener listener)
+    public AnsibleAdHocCommandInvocation(String exe, Run<?, ?> build, FilePath ws, TaskListener listener, EnvVars envVars)
             throws IOException, InterruptedException, AnsibleInvocationException
     {
-        super(exe, build, ws, listener);
+        super(exe, build, ws, listener, envVars);
     }
 
     public AnsibleAdHocCommandInvocation setHostPattern(String hostPattern) {

--- a/src/main/java/org/jenkinsci/plugins/ansible/AnsiblePlaybookBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AnsiblePlaybookBuilder.java
@@ -206,7 +206,7 @@ public class AnsiblePlaybookBuilder extends Builder implements SimpleBuildStep
         try {
             CLIRunner runner = new CLIRunner(run, ws, launcher, listener);
             String exe = AnsibleInstallation.getExecutable(ansibleName, AnsibleCommand.ANSIBLE_PLAYBOOK, node, listener, envVars);
-            AnsiblePlaybookInvocation invocation = new AnsiblePlaybookInvocation(exe, run, ws, listener);
+            AnsiblePlaybookInvocation invocation = new AnsiblePlaybookInvocation(exe, run, ws, listener, envVars);
             invocation.setPlaybook(playbook);
             invocation.setInventory(inventory);
             invocation.setLimit(limit);

--- a/src/main/java/org/jenkinsci/plugins/ansible/AnsiblePlaybookInvocation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AnsiblePlaybookInvocation.java
@@ -16,7 +16,9 @@
 package org.jenkinsci.plugins.ansible;
 
 import java.io.IOException;
+import java.util.Map;
 
+import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -37,16 +39,16 @@ public class AnsiblePlaybookInvocation extends AbstractAnsibleInvocation<Ansible
     private String skippedTags;
     private String startAtTask;
 
-    protected AnsiblePlaybookInvocation(String exe, AbstractBuild<?, ?> build, BuildListener listener)
+    protected AnsiblePlaybookInvocation(String exe, AbstractBuild<?, ?> build, BuildListener listener, EnvVars envVars)
             throws IOException, InterruptedException, AnsibleInvocationException
     {
-        this(exe, build, build.getWorkspace(), listener);
+        this(exe, build, build.getWorkspace(), listener, envVars);
     }
 
-    public AnsiblePlaybookInvocation(String exe, Run<?, ?> build, FilePath ws, TaskListener listener)
+    public AnsiblePlaybookInvocation(String exe, Run<?, ?> build, FilePath ws, TaskListener listener, EnvVars envVars)
             throws IOException, InterruptedException, AnsibleInvocationException
     {
-        super(exe, build, ws, listener);
+        super(exe, build, ws, listener, envVars);
     }
 
     public AnsiblePlaybookInvocation setPlaybook(String playbook) {


### PR DESCRIPTION
Right now the EnvVars are lost when the AbstractAnsibleInvocation is executed. Instead of using the EnvVars from the AnsiblePlaybookStep they are build from `currentComputer`.

This commit makes use of the original EnvVars.