### PR TITLE
Escape % in private key path

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleInvocation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleInvocation.java
@@ -178,7 +178,7 @@ abstract class AbstractAnsibleInvocation<T extends AbstractAnsibleInvocation<T>>
         if (credentials instanceof SSHUserPrivateKey) {
             SSHUserPrivateKey privateKeyCredentials = (SSHUserPrivateKey)credentials;
             key = Utils.createSshKeyFile(key, ws, privateKeyCredentials, copyCredentialsInWorkspace);
-            args.add("--private-key").add(key);
+            args.add("--private-key").add(key.toString().replace("%", "%%"));
             args.add("-u").add(privateKeyCredentials.getUsername());
             if (privateKeyCredentials.getPassphrase() != null) {
                 script = Utils.createSshAskPassFile(script, ws, privateKeyCredentials, copyCredentialsInWorkspace);


### PR DESCRIPTION
SSH interprets it as a variable substitution, which is undesireable.

I have a multi-branch pipeline project, whose branch names include slashes. When ansible writes out its private key file, it's written to the workspace, which, due to the slash in the branch name, contains `%2F` in place of the slash. Then, when ansible-playbook is run, it runs SSH, passing it the path of the private key file, whose path contains a `%`, and which SSH tries to interpret using its own path substitution rules (see `ssh_config(5)` for more info), and errors out.

This fix is not pretty, it gives up the `FilePath` for a bare string, and I'm sure there are better ways to fix this, but I know next to 0 java and 0 about Jenkins, so just getting this built and working on my local installation felt like a victory in and of itself.

Thanks for all your work on the ansible plugin. 😃 
