### PR TITLE
Adding forks parameter to pipeline step

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible/workflow/AnsiblePlaybookStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/workflow/AnsiblePlaybookStep.java
@@ -70,6 +70,7 @@ public class AnsiblePlaybookStep extends AbstractStepImpl {
     private Map extraVars = null;
     private String extras = null;
     private boolean colorized = false;
+    private Integer forks = 5;
 
     @DataBoundConstructor
     public AnsiblePlaybookStep(String playbook) {
@@ -136,6 +137,11 @@ public class AnsiblePlaybookStep extends AbstractStepImpl {
         this.colorized = colorized;
     }
 
+    @DataBoundSetter
+    public void setForks(Integer forks) {
+        this.forks = forks;
+    }
+
     public String getInstallation() {
         return installation;
     }
@@ -186,6 +192,10 @@ public class AnsiblePlaybookStep extends AbstractStepImpl {
 
     public boolean isColorized() {
         return colorized;
+    }
+
+    public Integer getForks() {
+        return forks;
     }
 
     @Extension
@@ -277,7 +287,7 @@ public class AnsiblePlaybookStep extends AbstractStepImpl {
             builder.setSudo(step.isSudo());
             builder.setSudoUser(step.getSudoUser());
             builder.setCredentialsId(step.getCredentialsId(), true);
-            builder.setForks(5);
+            builder.setForks(step.getForks());
             builder.setLimit(step.getLimit());
             builder.setTags(step.getTags());
             builder.setStartAtTask(step.getStartAtTask());

--- a/src/main/resources/org/jenkinsci/plugins/ansible/workflow/AnsiblePlaybookStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ansible/workflow/AnsiblePlaybookStep/config.jelly
@@ -30,6 +30,9 @@
     <f:entry field="startAtTask" title="Task to start at">
         <f:textbox/>
     </f:entry>
+    <f:entry field="forks" title="Number of parallel processes to use">
+        <f:textbox/>
+    </f:entry>
     <f:entry field="colorized" title="${%Colorized output}">
       <f:checkbox default="false" />
     </f:entry>


### PR DESCRIPTION
Currently parallel forks is hardcoded to 5 (ansible -f argument) in the pipeline step. This adds ability to specify number of forks desired with the `forks` argument, defaulting to 5.

eg 
```
ansiblePlaybook playbook: 'my-playbook.yml', forks: 20
```