### PR TITLE
Do not build a wrong ansible command with mishandled field expansion

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleInvocation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleInvocation.java
@@ -147,11 +147,27 @@ abstract class AbstractAnsibleInvocation<T extends AbstractAnsibleInvocation<T>>
     protected ArgumentListBuilder appendSudo(ArgumentListBuilder args) {
         if (sudo) {
             args.add("-s");
-            if (StringUtils.isNotBlank(sudoUser)) {
-                args.add("-U").add(envVars.expand(sudoUser));
-            }
+            addOptionAndValue(args, "-U", sudoUser);
         }
         return args;
+    }
+
+    protected void addOptionAndValue(final ArgumentListBuilder args, final String option, final String value) {
+        if (StringUtils.isNotBlank(value)) {
+            String expandedValue = envVars.expand(value);
+            if (StringUtils.isNotBlank(expandedValue)) {
+                args.add(option).add(expandedValue);
+            }
+        }
+    }
+
+    protected void addKeyValuePair(final ArgumentListBuilder args, final String key, final String value) {
+        if (StringUtils.isNotBlank(value)) {
+            String expandedValue = envVars.expand(value);
+            if (StringUtils.isNotBlank(expandedValue)) {
+                args.addKeyValuePair("", key, expandedValue, false);
+            }
+        }
     }
 
     public T setCredentials(StandardUsernameCredentials credentials) {

--- a/src/main/java/org/jenkinsci/plugins/ansible/AnsibleAdHocCommandInvocation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AnsibleAdHocCommandInvocation.java
@@ -18,13 +18,11 @@ package org.jenkinsci.plugins.ansible;
 import java.io.IOException;
 
 import hudson.FilePath;
-import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.ArgumentListBuilder;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Invoke the ansible command
@@ -62,10 +60,8 @@ public class AnsibleAdHocCommandInvocation extends AbstractAnsibleInvocation<Ans
         return this;
     }
 
-    private ArgumentListBuilder appendHModule(ArgumentListBuilder args) {
-        if (StringUtils.isNotBlank(module)) {
-            args.add("-m").add(envVars.expand(module));
-        }
+    private ArgumentListBuilder appendModule(ArgumentListBuilder args) {
+        addOptionAndValue(args, "-m", module);
         return args;
     }
 
@@ -75,9 +71,7 @@ public class AnsibleAdHocCommandInvocation extends AbstractAnsibleInvocation<Ans
     }
 
     public ArgumentListBuilder appendModuleCommand(ArgumentListBuilder args) {
-        if (StringUtils.isNotBlank(command)) {
-            args.add("-a").add(envVars.expand(command));
-        }
+        addOptionAndValue(args, "-a", command);
         return args;
     }
 
@@ -90,7 +84,7 @@ public class AnsibleAdHocCommandInvocation extends AbstractAnsibleInvocation<Ans
         appendExecutable(args);
         appendHostPattern(args);
         appendInventory(args);
-        appendHModule(args);
+        appendModule(args);
         appendModuleCommand(args);
         appendSudo(args);
         appendForks(args);

--- a/src/main/java/org/jenkinsci/plugins/ansible/AnsiblePlaybookInvocation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AnsiblePlaybookInvocation.java
@@ -18,13 +18,11 @@ package org.jenkinsci.plugins.ansible;
 import java.io.IOException;
 
 import hudson.FilePath;
-import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.ArgumentListBuilder;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Invoke the ansible-playbook command
@@ -65,9 +63,7 @@ public class AnsiblePlaybookInvocation extends AbstractAnsibleInvocation<Ansible
     }
 
     private ArgumentListBuilder appendLimit(ArgumentListBuilder args) {
-        if (StringUtils.isNotBlank(limit)) {
-            args.add("-l").add(envVars.expand(limit));
-        }
+        addOptionAndValue(args, "-l", limit);
         return args;
     }
 
@@ -77,9 +73,7 @@ public class AnsiblePlaybookInvocation extends AbstractAnsibleInvocation<Ansible
     }
 
     private ArgumentListBuilder appendTags(ArgumentListBuilder args) {
-        if (StringUtils.isNotBlank(tags)) {
-            args.add("-t").add(envVars.expand(tags));
-        }
+        addOptionAndValue(args, "-t", tags);
         return args;
     }
 
@@ -89,9 +83,7 @@ public class AnsiblePlaybookInvocation extends AbstractAnsibleInvocation<Ansible
     }
 
     private ArgumentListBuilder appendSkippedTags(ArgumentListBuilder args) {
-        if (StringUtils.isNotBlank(skippedTags)) {
-            args.addKeyValuePair("", "--skip-tags", envVars.expand(skippedTags), false);
-        }
+        addKeyValuePair(args, "--skip-tags", skippedTags);
         return args;
     }
 
@@ -101,9 +93,7 @@ public class AnsiblePlaybookInvocation extends AbstractAnsibleInvocation<Ansible
     }
 
     private ArgumentListBuilder appendStartTask(ArgumentListBuilder args) {
-        if (StringUtils.isNotBlank(startAtTask)) {
-            args.addKeyValuePair("", "--start-at-task", envVars.expand(startAtTask), false);
-        }
+        addKeyValuePair(args, "--start-at-task", startAtTask);
         return args;
     }
 


### PR DESCRIPTION
If you have `tags=${myTagParam}` and if _myTagParam_ build parameter is blank, then the plugin will only write the _-t_ option without any tag name which leads the ansible-playbook command to fail. This is the same for few other options.

I use to configure my ansible jobs with build parameters to allow the user to provide whatever he wants without changing the job itself. The default value of these build parameters is blank.
 
This PR will check the result of the  expansion of several options that require a value in the end.


