### PR TITLE
[FIXED JENKINS-49055] Add method to populate New Vault Credentials

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleBuilderDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleBuilderDescriptor.java
@@ -62,6 +62,15 @@ public abstract class AbstractAnsibleBuilderDescriptor extends BuildStepDescript
                 CredentialsProvider.lookupCredentials(StandardCredentials.class, project));
     }
 
+    public ListBoxModel doFillNewVaultCredentialsIdItems(@AncestorInPath Project project) {
+        return new StandardListBoxModel()
+            .withEmptySelection()
+            .withMatching(anyOf(
+                instanceOf(FileCredentials.class),
+                instanceOf(StringCredentials.class)),
+                CredentialsProvider.lookupCredentials(StandardCredentials.class, project));
+    }
+
     public List<InventoryDescriptor> getInventories() {
         return Jenkins.getActiveInstance().getDescriptorList(Inventory.class);
     }

--- a/src/main/java/org/jenkinsci/plugins/ansible/AnsibleVaultInvocation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AnsibleVaultInvocation.java
@@ -79,7 +79,9 @@ public class AnsibleVaultInvocation extends AbstractAnsibleInvocation<AnsibleVau
     }
     
     private ArgumentListBuilder appendContent(ArgumentListBuilder args) {
-        args.addMasked(content);
+        if (content != null && !content.isEmpty()) {
+            args.addMasked(content);
+        }
         return args;
     }
 
@@ -89,7 +91,9 @@ public class AnsibleVaultInvocation extends AbstractAnsibleInvocation<AnsibleVau
     }
     
     private ArgumentListBuilder appendInput(ArgumentListBuilder args) {
-        args.add(input);
+        if (input != null && !input.isEmpty()) {
+            args.add(input);
+        }
         return args;
     }
 
@@ -121,7 +125,9 @@ public class AnsibleVaultInvocation extends AbstractAnsibleInvocation<AnsibleVau
     }
     
     private ArgumentListBuilder appendOutput(ArgumentListBuilder args) {
-        args.add(output);
+        if (output != null && !output.isEmpty()) {
+            args.add(output);
+        }
         return args;
     }
 


### PR DESCRIPTION
Add method to populate New Vault Credentials for freestyle job. Only call append when there is content since it was adding extra spaces, confusing the Ansible CLI invocation and further blocking the freestyle job.