### PR TITLE
[FIXED JENKINS-49061] Syntax Generator Does Not Generate 'become' Option

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible/workflow/AnsiblePlaybookStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/workflow/AnsiblePlaybookStep.java
@@ -109,6 +109,7 @@ public class AnsiblePlaybookStep extends AbstractStepImpl {
         this.vaultCredentialsId = Util.fixEmptyAndTrim(vaultCredentialsId);
     }
 
+    @DataBoundSetter
     public void setBecome(boolean become) {
         this.become = become;
     }

--- a/src/main/resources/org/jenkinsci/plugins/ansible/workflow/AnsiblePlaybookStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ansible/workflow/AnsiblePlaybookStep/config.jelly
@@ -19,13 +19,13 @@
         <f:checkbox/>
     </f:entry>
     <f:entry field="becomeUser" title="Become username">
-        <f:textbox/>
+        <f:textbox default="root"/>
     </f:entry>
     <f:entry field="sudo" title="Use sudo (deprecated)">
         <f:checkbox/>
     </f:entry>
     <f:entry field="sudoUser" title="Sudo username (deprecated)">
-        <f:textbox/>
+        <f:textbox default="root"/>
     </f:entry>
     <f:entry field="limit" title="Host subset">
         <f:textbox/>


### PR DESCRIPTION
Add @DataBoundSetter to setter method.
Add default values for becomeUser and sudoUser to avoid generating misleading snippet.