### PR TITLE
[FIXED JENKINS-43782] General Build Steps Do Not Work In Pipelines

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible/AnsibleAdHocCommandBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AnsibleAdHocCommandBuilder.java
@@ -182,7 +182,7 @@ public class AnsibleAdHocCommandBuilder extends Builder implements SimpleBuildSt
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath ws, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
         try {
             CLIRunner runner = new CLIRunner(run, ws, launcher, listener);
-            Computer computer = Computer.currentComputer();
+            Computer computer = ws.toComputer();
             if (computer == null) {
                 throw new AbortException("The ansible ad-hoc command build step requires to be launched on a node");
             }

--- a/src/main/java/org/jenkinsci/plugins/ansible/AnsiblePlaybookBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AnsiblePlaybookBuilder.java
@@ -212,7 +212,7 @@ public class AnsiblePlaybookBuilder extends Builder implements SimpleBuildStep
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath ws, @Nonnull Launcher launcher, @Nonnull TaskListener listener)
             throws InterruptedException, IOException
     {
-        Computer computer = Computer.currentComputer();
+        Computer computer = ws.toComputer();
         Node node;
         if (computer == null || (node = computer.getNode()) == null) {
             throw new AbortException("The ansible playbook build step requires to be launched on a node");

--- a/src/main/java/org/jenkinsci/plugins/ansible/AnsibleVaultBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AnsibleVaultBuilder.java
@@ -103,7 +103,7 @@ public class AnsibleVaultBuilder extends Builder implements SimpleBuildStep
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath ws, @Nonnull Launcher launcher, @Nonnull TaskListener listener)
             throws InterruptedException, IOException
     {
-        Computer computer = Computer.currentComputer();
+        Computer computer = ws.toComputer();
         Node node;
         if (computer == null || (node = computer.getNode()) == null) {
             throw new AbortException("The ansible vault build step requires to be launched on a node");


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-43782

Get Computer object off the workspace instead of static Computer method.

Source: https://groups.google.com/forum/#!topic/jenkinsci-dev/MwdVHQ-lbvc
"You can get the `Node`/`Computer` from the `FilePath workspace` (which will work for freestyle builds, too)"