### PR TITLE
Fix examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ steps {
         forks(int forks = 5)
         unbufferedOutput(boolean unbufferedOutput = true)
         colorizedOutput(boolean colorizedOutput = false)
-        hostKeyChecking(boolean hostKeyChecking = false)
+        disableHostKeyChecking(boolean disableHostKeyChecking = false)
         additionalParameters(String params)
         extraVars {
             extraVar(String key, String value, boolean hidden)
@@ -58,7 +58,7 @@ steps {
         forks(int forks = 5)
         unbufferedOutput(boolean unbufferedOutput = true)
         colorizedOutput(boolean colorizedOutput = false)
-        hostKeyChecking(boolean hostKeyChecking = false)
+        disableHostKeyChecking(boolean disableHostKeyChecking = false)
         additionalParameters(String params)
         extraVars {
             extraVar(String key, String value, boolean hidden)


### PR DESCRIPTION
The change in https://github.com/jenkinsci/ansible-plugin/commit/06d30e5b626a978e258a7f4ab473cd7f53a7cba7 updated the parameter for checking host keys but did not update the README file to reflect those changes.