### PR TITLE
JENKINS-37387 - Adding @Symbol to AnsibleInstallation to be able to use it on tools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,12 @@
       <version>${job-dsl.version}</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>symbol-annotation</artifactId>
+      <version>${symbol-annotation.version}</version>
+      <optional>true</optional>
+    </dependency>
     <!-- Test -->
     <dependency>
       <groupId>junit</groupId>
@@ -158,6 +164,7 @@
     <assertj.version>1.7.1</assertj.version>
     <commons-lang.version>3.4</commons-lang.version>
     <job-dsl.version>1.36</job-dsl.version>
+    <symbol-annotation.version>1.14</symbol-annotation.version>
   </properties>
 
 </project>

--- a/src/main/java/org/jenkinsci/plugins/ansible/AnsibleInstallation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AnsibleInstallation.java
@@ -15,10 +15,6 @@
  */
 package org.jenkinsci.plugins.ansible;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.List;
-
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -32,8 +28,13 @@ import hudson.tools.ToolInstallation;
 import hudson.tools.ToolProperty;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
 
 /**
  * {@code ToolInstallation} for Ansible
@@ -114,6 +115,7 @@ public class AnsibleInstallation extends ToolInstallation
     }
 
     @Extension
+    @Symbol("ansible")
     public static class DescriptorImpl extends ToolDescriptor<AnsibleInstallation> {
 
         public DescriptorImpl() {


### PR DESCRIPTION
Fixes JENKINS-37387.

Now it can be used on tools section of the Jenkins pipeline like this:

```
tools {
    ansible '2.3.2.0'
}
```