### PR TITLE
move docs to GitHub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <packaging>hpi</packaging>
   <name>Jenkins Ansible plugin</name>
   <description>Ansible support in Jenkins</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Ansible+Plugin</url>
+  <url>https://github.com/jenkinsci/ansible-plugin</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
update the `<url>` field so that plugin docs points to GitHub
see https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/#how-to-enable-github-documentation-for-your-plugin