### PR TITLE
remove defaults jobsdsl forks value

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ steps {
         becomeUser(String user = 'root')
         sudo(boolean sudo = true)
         sudoUser(String user = 'root')
-        forks(int forks = 5)
+        forks(int forks)
         unbufferedOutput(boolean unbufferedOutput = true)
         colorizedOutput(boolean colorizedOutput = false)
         hostKeyChecking(boolean hostKeyChecking = false)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ steps {
         becomeUser(String user = 'root')
         sudo(boolean sudo = true)
         sudoUser(String user = 'root')
-        forks(int forks = 5)
+        forks(int forks)
         unbufferedOutput(boolean unbufferedOutput = true)
         colorizedOutput(boolean colorizedOutput = false)
         hostKeyChecking(boolean hostKeyChecking = false)

--- a/src/main/java/org/jenkinsci/plugins/ansible/jobdsl/context/AnsibleContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/jobdsl/context/AnsibleContext.java
@@ -28,7 +28,7 @@ public class AnsibleContext implements Context {
     private String becomeUser = "root";
     private boolean sudo = false;
     private String sudoUser = "root";
-    private int forks = 5;
+    private int forks;
     private boolean unbufferedOutput = true;
     private boolean colorizedOutput = false;
     private boolean disableHostKeyChecking = false;

--- a/src/test/java/org/jenkinsci/plugins/ansible/jobdsl/JobDslIntegrationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible/jobdsl/JobDslIntegrationTest.java
@@ -112,7 +112,7 @@ public class JobDslIntegrationTest {
         assertThat("hostPattern", step.hostPattern, is("pattern"));
         assertThat("become", step.become, is(false));
         assertThat("becomeUser", step.becomeUser, is("root"));
-        assertThat("forks", step.forks, is(5));
+        assertThat("forks", step.forks, is(0));
         assertThat("unbufferedOutput", step.unbufferedOutput, is(true));
         assertThat("colorizedOutput", step.colorizedOutput, is(false));
         assertThat("disableHostKeyChecking", step.disableHostKeyChecking, is(false));


### PR DESCRIPTION
We noticed that although this default lines up with ansible's default value of 5, it also overrides any nondefault value you have set in your ansible configuration. This is a little unfriendly to users who might want to manage ansible config separate from jobs dsl config. 