### PR TITLE
JENKINS-52292 - Support Multiple Vault IDs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleInvocation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleInvocation.java
@@ -251,11 +251,11 @@ abstract class AbstractAnsibleInvocation<T extends AbstractAnsibleInvocation<T>>
             if (vaultCredentials instanceof FileCredentials) {
                 FileCredentials secretFile = (FileCredentials)vaultCredentials;
                 vaultPassword = Utils.createVaultPasswordFile(vaultPassword, ws, secretFile);
-                args.add("--vault-password-file").add(vaultPassword.getRemote().replace("%", "%%"));
+                args.add("--vault-id").add(vaultPassword.getRemote().replace("%", "%%"));
             } else if (vaultCredentials instanceof StringCredentials) {
                 StringCredentials secretText = (StringCredentials)vaultCredentials;
                 vaultPassword = Utils.createVaultPasswordFile(vaultPassword, ws, secretText);
-                args.add("--vault-password-file").add(vaultPassword.getRemote().replace("%", "%%"));
+                args.add("--vault-id").add(vaultPassword.getRemote().replace("%", "%%"));
             }
         }
         return args;

--- a/src/main/resources/org/jenkinsci/plugins/ansible/AnsibleAdHocCommandBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ansible/AnsibleAdHocCommandBuilder/config.jelly
@@ -32,8 +32,10 @@
     <c:select/>
   </f:entry>
 
-  <f:entry title="${%Vault Credentials}" field="vaultCredentialsId">
-    <c:select/>
+  <f:entry title="${%Vault Credentials}">
+    <f:repeatable add="${%Add Extra Credential}" field="vaultCredentialsId" noAddButton="false">
+      <c:select/>
+	</f:repeatable>
   </f:entry>
 
   <f:optionalBlock name="become" title="${%become}" checked="${instance.become}" inline="true" help="${descriptor.getHelpFile('become')}">

--- a/src/main/resources/org/jenkinsci/plugins/ansible/AnsibleAdHocCommandBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ansible/AnsibleAdHocCommandBuilder/config.jelly
@@ -35,7 +35,7 @@
   <f:entry title="${%Vault Credentials}">
     <f:repeatable add="${%Add Extra Credential}" field="vaultCredentialsId" noAddButton="false">
       <c:select/>
-	</f:repeatable>
+    </f:repeatable>
   </f:entry>
 
   <f:optionalBlock name="become" title="${%become}" checked="${instance.become}" inline="true" help="${descriptor.getHelpFile('become')}">

--- a/src/main/resources/org/jenkinsci/plugins/ansible/AnsiblePlaybookBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ansible/AnsiblePlaybookBuilder/config.jelly
@@ -31,7 +31,7 @@
   <f:entry title="${%Vault Credentials}">
     <f:repeatable add="${%Add Extra Credential}" field="vaultCredentialsId" noAddButton="false">
       <c:select/>
-	</f:repeatable>
+    </f:repeatable>
   </f:entry>
 
   <f:optionalBlock name="become" title="${%become}" checked="${instance.become}" inline="true" help="${descriptor.getHelpFile('become')}">

--- a/src/main/resources/org/jenkinsci/plugins/ansible/AnsiblePlaybookBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ansible/AnsiblePlaybookBuilder/config.jelly
@@ -28,8 +28,10 @@
     <c:select/>
   </f:entry>
 
-  <f:entry title="${%Vault Credentials}" field="vaultCredentialsId">
-    <c:select/>
+  <f:entry title="${%Vault Credentials}">
+    <f:repeatable add="${%Add Extra Credential}" field="vaultCredentialsId" noAddButton="false">
+      <c:select/>
+	</f:repeatable>
   </f:entry>
 
   <f:optionalBlock name="become" title="${%become}" checked="${instance.become}" inline="true" help="${descriptor.getHelpFile('become')}">

--- a/src/main/resources/org/jenkinsci/plugins/ansible/AnsibleVaultBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ansible/AnsibleVaultBuilder/config.jelly
@@ -19,7 +19,7 @@
   <f:entry title="${%Vault Credentials}">
     <f:repeatable add="${%Add Extra Credential}" field="vaultCredentialsId" noAddButton="false">
       <c:select/>
-	</f:repeatable>
+    </f:repeatable>
   </f:entry>
 
   <f:entry title="${%New Vault Credentials}" field="newVaultCredentialsId">

--- a/src/main/resources/org/jenkinsci/plugins/ansible/AnsibleVaultBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ansible/AnsibleVaultBuilder/config.jelly
@@ -16,8 +16,10 @@
     <f:textbox/>
   </f:entry>
 
-  <f:entry title="${%Vault Credentials}" field="vaultCredentialsId">
-    <c:select/>
+  <f:entry title="${%Vault Credentials}">
+    <f:repeatable add="${%Add Extra Credential}" field="vaultCredentialsId" noAddButton="false">
+      <c:select/>
+	</f:repeatable>
   </f:entry>
 
   <f:entry title="${%New Vault Credentials}" field="newVaultCredentialsId">


### PR DESCRIPTION
This request is related to: https://issues.jenkins.io/browse/JENKINS-52292
--vault-password-file changed to --vault-id as described in: https://docs.ansible.com/ansible/2.4/vault.html#providing-vault-passwords
added extra credential button