### PR TITLE
[JENKINS-54929] Always flush the output logger on the TaskListener

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible/CLIRunner.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/CLIRunner.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.ansible;
 
 import java.io.IOException;
+import java.io.PrintStream;
 import java.util.Map;
 
 import hudson.FilePath;
@@ -42,10 +43,17 @@ public class CLIRunner
     public boolean execute(ArgumentListBuilder args, Map<String, String> environment)
             throws IOException, InterruptedException
     {
-        return launcher.launch()
-                .pwd(ws)
-                .envs(environment)
-                .cmds(args)
-                .stdout(listener).join() == 0;
+        PrintStream logger = listener.getLogger();
+        try {
+            return launcher.launch()
+                    .pwd(ws)
+                    .envs(environment)
+                    .cmds(args)
+                    .stdout(logger)
+                    .stderr(logger).join() == 0;
+        }
+        finally {
+            logger.flush();
+        }
     }
 }


### PR DESCRIPTION
Supersede https://github.com/jenkinsci/ansible-plugin/pull/30 and rebased on master

 - Extract the logger out of the TaskListener and pass it to the stdout/stderr methods of the Launcher
 - Trap all errors and force a flush of the logger once the command has completed

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
