### PR TITLE
Bump jenkins core to support new version of JobDSL plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/ansible-plugin</gitHubRepo>
-    <jenkins.version>2.375.4</jenkins.version>
+    <jenkins.version>2.387.1</jenkins.version>
   </properties>
   <licenses>
     <license>
@@ -34,7 +34,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.375.x</artifactId>
+        <artifactId>bom-2.387.x</artifactId>
         <version>1935.v530f4395930f</version>
         <scope>import</scope>
         <type>pom</type>


### PR DESCRIPTION
Bump jenkins core to 2.387.1 to support new version of JobDSL plugin

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
