### PR TITLE
[JENKINS-49812] quote CLI-based sshpass password to prevent shell interference

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleInvocation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleInvocation.java
@@ -215,7 +215,7 @@ abstract class AbstractAnsibleInvocation<T extends AbstractAnsibleInvocation<T>>
     protected ArgumentListBuilder prependPasswordCredentials(ArgumentListBuilder args) {
         if (credentials instanceof UsernamePasswordCredentials) {
             UsernamePasswordCredentials passwordCredentials = (UsernamePasswordCredentials)credentials;
-            args.add("sshpass").addMasked("-p" + Secret.toString(passwordCredentials.getPassword()));
+            args.add("sshpass").addQuoted("-p" + Secret.toString(passwordCredentials.getPassword()), true);
         }
         return args;
     }


### PR DESCRIPTION
Hi, first of all thanks for the great plugin!

Related Issue: https://issues.jenkins.io/browse/JENKINS-49812

I noticed that while using the `credentialsId` parameter with "username with password" credentials, some passwords (for example passwords containing `$`) are not passed correctly to the `sshpass` binary. I suspect this is due to missing quoting of the password in the construction of the command line string. I do not know who interprets this string along the way, but I suspect it's the shell.

My attempt at fixing this is using the `addQuoted` method instead of the `addMasked` method to add the command line arguments.

### Testing done
I did not test this change since I don't know how to; please forgive me 🙂.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
