### PR TITLE
JENKINS-49812 Escape shell special characters

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleInvocation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleInvocation.java
@@ -215,9 +215,13 @@ abstract class AbstractAnsibleInvocation<T extends AbstractAnsibleInvocation<T>>
     protected ArgumentListBuilder prependPasswordCredentials(ArgumentListBuilder args) {
         if (credentials instanceof UsernamePasswordCredentials) {
             UsernamePasswordCredentials passwordCredentials = (UsernamePasswordCredentials)credentials;
-            args.add("sshpass").addMasked("-p" + Secret.toString(passwordCredentials.getPassword()));
+            args.add("sshpass").addMasked("-p" + escapeSpecialCharacters(Secret.toString(passwordCredentials.getPassword())));
         }
         return args;
+    }
+
+    protected String escapeSpecialCharacters(String input) {
+        return input.replaceAll("[!\\\"#$%&'()*+,-./:;<=>?@[\\\\\\\\]^`{|}~]", "\\\\$0");
     }
 
     protected ArgumentListBuilder appendCredentials(ArgumentListBuilder args)


### PR DESCRIPTION
JENKINS-49812 Escape shell special characters

It's the only solution I found to work with sshpass and ArgumentListBuilder

### Testing done

Install sshpass, create a user with special character password and use it to connect.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
