### PR TITLE
Handle Number-typed extra var values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,8 +487,10 @@ node {
 
 ### Extra Variables
 
-Extra variables can be passed to ansible by using a map in the pipeline script. Use the `hidden` parameter
-to keep the variable secret in the build log.
+Extra variables can be passed to ansible by using a map in the pipeline script.
+Supported value types are: `String`, `Boolean`, `Number`.
+By default the value will be considered potentially sensitive and masked in the logs.
+To override this give a map with keys `value` and `hidden`.
 
 ```groovy
 node {
@@ -497,7 +499,9 @@ node {
         playbook: 'cloud_playbooks/create-aws.yml',
         extraVars: [
             login: 'mylogin',
-            secret_key: [value: 'g4dfKWENpeF6pY05', hidden: true]
+            toggle: true,
+            forks: 8,
+            not_secret: [value: 'I want to see this in the logs', hidden: false]
         ])
 }
 ```

--- a/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleInvocation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AbstractAnsibleInvocation.java
@@ -120,6 +120,10 @@ abstract class AbstractAnsibleInvocation<T extends AbstractAnsibleInvocation<T>>
     public ArgumentListBuilder appendExtraVars(ArgumentListBuilder args) {
         if (extraVars != null && ! extraVars.isEmpty()) {
             for (ExtraVar var : extraVars) {
+                if (var.getSecretValue() == null) {
+                    listener.getLogger().println("[WARN] Omitting extra var " + var.getKey() + ": check value is a supported type.");
+                    continue;
+                }
                 args.add("-e");
                 String value = envVars.expand(var.getSecretValue().getPlainText());
                 if (Pattern.compile("\\s").matcher(value).find()) {

--- a/src/test/java/org/jenkinsci/plugins/ansible/PipelineTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible/PipelineTest.java
@@ -88,6 +88,18 @@ public class PipelineTest {
     }
 
     @Test
+    public void testExtraVarsNumeric() throws Exception {
+        String pipeline = IOUtils.toString(PipelineTest.class.getResourceAsStream("/pipelines/extraVarsNumeric.groovy"), StandardCharsets.UTF_8);
+        WorkflowJob workflowJob = jenkins.createProject(WorkflowJob.class);
+        workflowJob.setDefinition(new CpsFlowDefinition(pipeline, true));
+        WorkflowRun run1 = workflowJob.scheduleBuild2(0).waitForStart();
+        jenkins.waitForCompletion(run1);
+        assertThat(run1.getLog(), allOf(
+                containsString("ansible-playbook playbook.yml -e ********")
+        ));
+    }
+
+    @Test
     public void testAnsiblePlaybookSshPass() throws Exception {
 
         UsernamePasswordCredentialsImpl usernamePassword = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "usernamePasswordCredentialsId", "test username password", "username", "password");

--- a/src/test/resources/pipelines/extraVarsNumeric.groovy
+++ b/src/test/resources/pipelines/extraVarsNumeric.groovy
@@ -1,0 +1,27 @@
+pipeline {
+    agent {
+        label('test-agent')
+    }
+    stages {
+        stage('Create playbook') {
+            steps {
+                writeFile(encoding: 'UTF-8', file: 'playbook.yml', text: '''- hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+    - debug: msg=test
+                ''')
+            }
+        }
+        stage('Ansible playbook') {
+            steps {
+                warnError(message: 'ansible command not found?') {
+                    ansiblePlaybook(
+                            playbook: 'playbook.yml',
+                            extraVars: [foo1: 8],
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION

Modifies `AnsiblePlaybookStep` to include handling of `Number`-valued extra vars. _E.g._

```
ansiblePlaybook(
   playbook: 'playbook.yml',
   extraVars: [serial_override: 8],
)
```

Current behaviour is to create `ExtraVar` instance that has a `null` `secretValue`, which triggers a `NullPointerException` in `AbstractAnsibleInvocation`.

This PR:
1. Improves handling of `extraVars` in `AnsiblePlaybookStep` to deal with `Number`-typed values correctly.
2. Improves handling of `[value: ..., hidden: ...]` style values so that:
    1. Can handle `Boolean` and `Number` values (current code can only handle `String` values), and
    2. Can handle non-`Boolean` values for `hidden`, and adopts the safe default of `hidden=true`.
        For example if someone accidentally does this: `[value:'my_secret', hidden:'true']` it will do the safe thing.
3. Improves handling of cases where someone gives a value type that can't be handled. Instead of exploding with a `NullPointerException`, it emits a clear warning in the logs and omits that extra var.
4. Updates the README concerning extra vars in pipelines to be clear about what type of values are supported.

This will fix https://github.com/jenkinsci/ansible-plugin/issues/87.

### Testing done

* I have added a test case for a `Number`-typed extra var value.
* This PR was prompted by jobs on my company's Jenkins server failing. I have confirmed that the failure is only observed with jobs where the pipeline uses a `Number`-typed extra var. I have deployed a custom build with the changes in this PR and confirmed it fixes the failure for my Jenkins instance.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
