### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible/AnsibleAdHocCommandBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AnsibleAdHocCommandBuilder.java
@@ -18,6 +18,7 @@ package org.jenkinsci.plugins.ansible;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.EnvVars;
@@ -33,7 +34,6 @@ import hudson.util.FormValidation;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import javax.annotation.Nonnull;
 import jenkins.tasks.SimpleBuildStep;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -227,7 +227,7 @@ public class AnsibleAdHocCommandBuilder extends Builder implements SimpleBuildSt
 
     @Override
     public void perform(
-            @Nonnull Run<?, ?> run, @Nonnull FilePath ws, @Nonnull Launcher launcher, @Nonnull TaskListener listener)
+            @NonNull Run<?, ?> run, @NonNull FilePath ws, @NonNull Launcher launcher, @NonNull TaskListener listener)
             throws InterruptedException, IOException {
         try {
             CLIRunner runner = new CLIRunner(run, ws, launcher, listener);

--- a/src/main/java/org/jenkinsci/plugins/ansible/AnsiblePlaybookBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AnsiblePlaybookBuilder.java
@@ -18,6 +18,7 @@ package org.jenkinsci.plugins.ansible;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.EnvVars;
@@ -35,7 +36,6 @@ import hudson.util.FormValidation;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import javax.annotation.Nonnull;
 import jenkins.tasks.SimpleBuildStep;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -266,7 +266,7 @@ public class AnsiblePlaybookBuilder extends Builder implements SimpleBuildStep {
 
     @Override
     public void perform(
-            @Nonnull Run<?, ?> run, @Nonnull FilePath ws, @Nonnull Launcher launcher, @Nonnull TaskListener listener)
+            @NonNull Run<?, ?> run, @NonNull FilePath ws, @NonNull Launcher launcher, @NonNull TaskListener listener)
             throws InterruptedException, IOException {
         Computer computer = ws.toComputer();
         Node node;
@@ -277,11 +277,11 @@ public class AnsiblePlaybookBuilder extends Builder implements SimpleBuildStep {
     }
 
     public void perform(
-            @Nonnull Run<?, ?> run,
-            @Nonnull Node node,
-            @Nonnull FilePath ws,
-            @Nonnull Launcher launcher,
-            @Nonnull TaskListener listener,
+            @NonNull Run<?, ?> run,
+            @NonNull Node node,
+            @NonNull FilePath ws,
+            @NonNull Launcher launcher,
+            @NonNull TaskListener listener,
             EnvVars envVars)
             throws InterruptedException, IOException {
         try {

--- a/src/main/java/org/jenkinsci/plugins/ansible/AnsibleVaultBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible/AnsibleVaultBuilder.java
@@ -15,6 +15,7 @@ package org.jenkinsci.plugins.ansible;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.EnvVars;
@@ -31,7 +32,6 @@ import hudson.tasks.Builder;
 import hudson.util.FormValidation;
 import java.io.File;
 import java.io.IOException;
-import javax.annotation.Nonnull;
 import jenkins.tasks.SimpleBuildStep;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -114,7 +114,7 @@ public class AnsibleVaultBuilder extends Builder implements SimpleBuildStep {
 
     @Override
     public void perform(
-            @Nonnull Run<?, ?> run, @Nonnull FilePath ws, @Nonnull Launcher launcher, @Nonnull TaskListener listener)
+            @NonNull Run<?, ?> run, @NonNull FilePath ws, @NonNull Launcher launcher, @NonNull TaskListener listener)
             throws InterruptedException, IOException {
         Computer computer = ws.toComputer();
         Node node;
@@ -125,11 +125,11 @@ public class AnsibleVaultBuilder extends Builder implements SimpleBuildStep {
     }
 
     public void perform(
-            @Nonnull Run<?, ?> run,
-            @Nonnull Node node,
-            @Nonnull FilePath ws,
-            @Nonnull Launcher launcher,
-            @Nonnull TaskListener listener,
+            @NonNull Run<?, ?> run,
+            @NonNull Node node,
+            @NonNull FilePath ws,
+            @NonNull Launcher launcher,
+            @NonNull TaskListener listener,
             EnvVars envVars)
             throws InterruptedException, IOException {
         try {


### PR DESCRIPTION
## Replace JSR-305 annotations with spotbugs annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the tutorial.

### Testing done

Confirmed that automated tests pass on Linux with Java 21.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
